### PR TITLE
Lazy insert creation testing & complex schema support

### DIFF
--- a/entity/lib/ops/hydrate.js
+++ b/entity/lib/ops/hydrate.js
@@ -63,7 +63,7 @@ module.exports = function (entity, hydrate_options, callback) {
 
       // prevent infinite recursion & ensure we only add the fn to ops 1 time.
       if (!ops[c.model_type] && !(entity.attrs.id === c.model_id && entity.model_type === c.model_type)) {
-        ops[c.model_type] = factory_model_list(app, content_ids, c.model_type, depth, types);
+        ops[c.model_type] = factory_model_list(app, content_ids, c.model_type, depth, hydrate_types);
       }
     }
   });

--- a/entity/lib/ops/hydrate.js
+++ b/entity/lib/ops/hydrate.js
@@ -105,13 +105,15 @@ var factory_model_list = function (app, content_ids, model_type, depth, types) {
         var ops = _.map(results, function (m) {
 
           //we only want to recurse active records
-          debug('model is:', m);
-
           return function (cbh) {
-            if (!m || !m.active) {
+            debug('m.attrs are:', m.attrs);
+
+            if (!m || !m.attrs.active) {
               return cbh(null, null);
             }
+
             debug('recursively hydrating: ', model_type, _.pick(m, ["id"]));
+
             app_plugin.hydrate(m, {
               depth: depth - 1,
               types: types

--- a/entity/lib/ops/hydrate.js
+++ b/entity/lib/ops/hydrate.js
@@ -95,7 +95,6 @@ var factory_model_list = function (app, content_ids, model_type, depth, types) {
       return cb(new Error("content model_type is not set or model_type plugin does not exist on app. " + model_type), null);
     }
 
-    debug('getting content ids of ', content_ids.length);
     app_plugin.get(content_ids[model_type], function (err, results) {
 
       // entities get recursively hydrated, models already are.
@@ -111,8 +110,6 @@ var factory_model_list = function (app, content_ids, model_type, depth, types) {
             if (!m || !m.attrs.active) {
               return cbh(null, null);
             }
-
-            debug('recursively hydrating: ', model_type, _.pick(m, ["id"]));
 
             app_plugin.hydrate(m, {
               depth: depth - 1,

--- a/entity/lib/ops/hydrate.js
+++ b/entity/lib/ops/hydrate.js
@@ -63,7 +63,7 @@ module.exports = function (entity, hydrate_options, callback) {
 
       // prevent infinite recursion & ensure we only add the fn to ops 1 time.
       if (!ops[c.model_type] && !(entity.attrs.id === c.model_id && entity.model_type === c.model_type)) {
-        ops[c.model_type] = factory_model_list(app, content_ids, c.model_type, depth);
+        ops[c.model_type] = factory_model_list(app, content_ids, c.model_type, depth, types);
       }
     }
   });
@@ -78,7 +78,7 @@ module.exports = function (entity, hydrate_options, callback) {
 };
 
 // generates a function for multi-get in hydrate.
-var factory_model_list = function (app, content_ids, model_type, depth) {
+var factory_model_list = function (app, content_ids, model_type, depth, types) {
 
   var app_plugin = app[model_type] ? app[model_type] : app[model_type + 's'];
 
@@ -103,7 +103,8 @@ var factory_model_list = function (app, content_ids, model_type, depth) {
             }
 
             app_plugin.hydrate(m, {
-              depth: depth - 1
+              depth: depth - 1,
+              types: types
             }, cbh);
           };
 

--- a/model/index.js
+++ b/model/index.js
@@ -208,6 +208,7 @@ module.exports = BasePlugin.extend({
     // NOTE: "this" is the plugin itself.  no need to use the getter/setter here.  Only on the interface exposed to users.
     var db_connection = create_couch_connection(couch_options);
     var self = this;
+    self.db = db_connection.use(couch_options.database);
 
     if (ensure_db) {
       // trying to ensure the design docs - if it fails create db.

--- a/model/lib/model.js
+++ b/model/lib/model.js
@@ -39,12 +39,7 @@ var Model = module.exports = BasePlugin.extend({
       _.each(this.history, function (row) {
 
         if (!timestamp || timestamp > row.updated_date) {
-
-          if (row.hasOwnProperty("base_entity_graph") && row.base_entity_graph.length == 0) {
-            row = _.without(row, "base_entity_graph");
-          }
-
-          record = _.extend(record || {}, row);
+          record = _.merge(record || {}, row);
         }
       });
 

--- a/model/lib/model.js
+++ b/model/lib/model.js
@@ -39,6 +39,11 @@ var Model = module.exports = BasePlugin.extend({
       _.each(this.history, function (row) {
 
         if (!timestamp || timestamp > row.updated_date) {
+
+          if (row.hasOwnProperty("base_entity_graph") && row.base_entity_graph.length == 0) {
+            row = _.without(row, "base_entity_graph");
+          }
+
           record = _.extend(record || {}, row);
         }
       });

--- a/model/lib/omit_nulls.js
+++ b/model/lib/omit_nulls.js
@@ -2,11 +2,12 @@ var _ = require('lodash');
 
 var omit_nulls = module.exports = function (obj) {
   return _.omit(obj || {}, function (value) {
-
+    //if this is an array - dig deeper
     if (value instanceof Array) {
       value = omit_nulls(value);
+    } else {
+      return value === null;
     }
 
-    return value === null;
   });
 };

--- a/model/lib/omit_nulls.js
+++ b/model/lib/omit_nulls.js
@@ -1,7 +1,12 @@
 var _ = require('lodash');
 
-module.exports = function(obj) {
-  return _.omit(obj || {}, function(value) {
+var omit_nulls = module.exports = function (obj) {
+  return _.omit(obj || {}, function (value) {
+
+    if (value instanceof Array) {
+      value = omit_nulls(value);
+    }
+
     return value === null;
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiti",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "main": "index.js",
   "scripts": {
     "test": "mocha -R spec -u tdd test/model/tests/*.js && mocha -R spec -u tdd test/entity/tests/*.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiti",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "index.js",
   "scripts": {
     "test": "mocha -R spec -u tdd test/model/tests/*.js && mocha -R spec -u tdd test/entity/tests/*.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiti",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "main": "index.js",
   "scripts": {
     "test": "mocha -R spec -u tdd test/model/tests/*.js && mocha -R spec -u tdd test/entity/tests/*.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiti",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "index.js",
   "scripts": {
     "test": "mocha -R spec -u tdd test/model/tests/*.js && mocha -R spec -u tdd test/entity/tests/*.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiti",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "index.js",
   "scripts": {
     "test": "mocha -R spec -u tdd test/model/tests/*.js && mocha -R spec -u tdd test/entity/tests/*.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiti",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "main": "index.js",
   "scripts": {
     "test": "mocha -R spec -u tdd test/model/tests/*.js && mocha -R spec -u tdd test/entity/tests/*.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiti",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "main": "index.js",
   "scripts": {
     "test": "mocha -R spec -u tdd test/model/tests/*.js && mocha -R spec -u tdd test/entity/tests/*.js"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "JSONStream": "^0.10.0",
     "async": "^0.9.0",
+    "debug": "^2.2.0",
     "deep-equal": "^1.0.0",
     "jsonschema": "^1.0.0",
     "lodash": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiti",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "main": "index.js",
   "scripts": {
     "test": "mocha -R spec -u tdd test/model/tests/*.js && mocha -R spec -u tdd test/entity/tests/*.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiti",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "main": "index.js",
   "scripts": {
     "test": "mocha -R spec -u tdd test/model/tests/*.js && mocha -R spec -u tdd test/entity/tests/*.js"


### PR DESCRIPTION
Modified the verification of db existence logic:

from: get list of all dbs from couch then see if I'm in it, if not - create me
to: try to ensure my design docs, and if that fails on db does not exist - create me

Fixed bug in our omission of nulls function (omit_nulls) used to jive data models before passing them through json schema validation(or).

We we're stepping into arrays, so sub-schema'ed objects like permissions weren't being sanitized properly.
